### PR TITLE
Fix mqtt client connection status flag

### DIFF
--- a/helyos_agent_sdk/mqtt_client.py
+++ b/helyos_agent_sdk/mqtt_client.py
@@ -134,6 +134,8 @@ class HelyOSMQTTClient():
     @property
     def is_connection_open(self):
         """ Check if the connection is open """
+        if self.connection is None:
+            return False
         return self.connection.is_connected()
 
 


### PR DESCRIPTION
Before accessing the connection, check if the object exists