### PR TITLE
Timeout on checkin result

### DIFF
--- a/helyos_agent_sdk/client.py
+++ b/helyos_agent_sdk/client.py
@@ -309,7 +309,7 @@ class HelyOSClient():
         :param checkin_guard_interceptor: An optional interceptor function to be called to validate the check-in response, returning True or False, defaults to None
         :type checkin_guard_interceptor: function
         """
-        if self.connection:
+        if self.connection and self.is_connection_open:
             self.__prepare_checkin_for_already_connected()
             username = self.rbmq_username
         else:


### PR DESCRIPTION
To retrieve the check-in result, do not block until a response arrives at the check-in queue. This caused the client to wait forever, blocking its logic.

We use now process_data_events(time_limit=timeout) with a default timeout of 10 seconds.

In addition, to decide between anonymous and not anonymous connection, we need to check if the connection is actually open, not only existent