### PR TITLE
Client has now the member yard_uid as client member.

### DIFF
--- a/helyos_agent_sdk/client.py
+++ b/helyos_agent_sdk/client.py
@@ -102,6 +102,7 @@ class HelyOSClient():
         self.is_reconecting = False
         self.rbmq_username = None
         self.rbmq_password = None
+        self.yard_uid = None
 
         if agent_pubkey is None or agent_privkey is None:
             self.private_key, self.public_key = generate_private_public_keys()


### PR DESCRIPTION
Client has now the member yard_uid as client member, initially set to None. When checking in, this gets assigned. Before the self.yard_uid was only present in the client after checking-in